### PR TITLE
fix(paddle): 在返回body中加入 signature 解决崩溃问题

### DIFF
--- a/Surge模块/crack.js
+++ b/Surge模块/crack.js
@@ -63,6 +63,7 @@ const paddleActivate = () => {
           expires: 1,
           expiry_date: 1999999999999,
         },
+        signature: '',
       }),
     },
   });
@@ -76,6 +77,7 @@ const paddleVerify = () => {
       expires: 1,
       expiry_date: 1999999999999,
     },
+    signature: '',
   });
   $done({
     response: {


### PR DESCRIPTION

<img width="634" alt="CleanShot 2024-02-25 at 14 42 43@2x" src="https://github.com/QiuChenlyOpenSource/91QiuChen/assets/62133302/67f788be-4b5d-4a7f-b161-4bf6a8074ad5">


fix #13 